### PR TITLE
fixed history side nav

### DIFF
--- a/database/migrations/2025_07_11_061436_create_conversation_title_table.php
+++ b/database/migrations/2025_07_11_061436_create_conversation_title_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateChatMessagesTable extends Migration
+class CreateConversationTitleTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,13 +13,11 @@ class CreateChatMessagesTable extends Migration
      */
     public function up()
     {
-        Schema::create('chat_messages', function (Blueprint $table) {
-            $table->bigIncrements('id');
+        Schema::create('conversation_title', function (Blueprint $table) {
+            $table->id();
             $table->unsignedBigInteger('message_id');
-            $table->enum('sender', ['ai', 'human']);
-            $table->text('topic');
+            $table->string('title');
             $table->timestamps();
-
             $table->foreign('message_id')->references('id')->on('sessions')->onDelete('cascade');
         });
     }
@@ -31,6 +29,6 @@ class CreateChatMessagesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('chat_messages');
+        Schema::dropIfExists('conversation_title');
     }
 }

--- a/resources/views/layouts/historysidenav.blade.php
+++ b/resources/views/layouts/historysidenav.blade.php
@@ -46,6 +46,10 @@
             padding: 120px 10px 40px;
         }
 
+        .sidebar.collapsed .delete-btn {
+            display: none !important;
+        }
+
         .sidebar h2 {
             font-size: 1.2rem;
             font-weight: 700;


### PR DESCRIPTION
## Summary by Sourcery

Replace chat_messages table with a conversation_title table migration and add styling to hide the delete button in the collapsed history sidebar.

Enhancements:
- Rename chat_messages migration to CreateConversationTitleTable and update the schema to use an auto-incrementing id, message_id foreign key, title string, and timestamps
- Update the down method to drop the conversation_title table
- Add a CSS rule to hide the delete button when the history sidebar is collapsed