### PR TITLE
Paolo

### DIFF
--- a/app/Console/Commands/Uvicorn.php
+++ b/app/Console/Commands/Uvicorn.php
@@ -107,7 +107,7 @@ $$/   $$/  $$$$$$/  $$/       $$/  $$/  $$/  $$$$$$$/ $$/
              [
                 'name' => '5 questions API',
                 'path' => base_path('python\five_questions'), // Directory where your Python file is
-                'file_and_app_instance' => 'five_questions_agent:app', // e.g., if you have main.py and `app = FastAPI()`
+                'file_and_app_instance' => 'five_question_agent:app', // e.g., if you have main.py and `app = FastAPI()`
                 'port' => 8008
             ],
           

--- a/app/Http/Controllers/FiveQuestion/FiveQuestionsController.php
+++ b/app/Http/Controllers/FiveQuestion/FiveQuestionsController.php
@@ -12,7 +12,7 @@ class FiveQuestionsController extends Controller
     public function fetchUserSessions()
     {
         $userId = Auth::id();
-        $response = Http::get("http://127.0.0.1:5001/sessions/$userId"); // Adjusted URL to match your FastAPI endpoint
+        $response = Http::get("http://localhost:8008/sessions/$userId"); // Adjusted URL to match your FastAPI endpoint
         return response()->json($response->json());
     }
     public function showForm()
@@ -37,7 +37,7 @@ class FiveQuestionsController extends Controller
 
         $response = Http::timeout(0)
             ->asMultipart()
-            ->post('http://127.0.0.1:5001/five_questions', $multipartData);  // Adjusted URL to match your FastAPI endpoint
+            ->post('http://localhost:8008/five_questions', $multipartData);  // Adjusted URL to match your FastAPI endpoint
 
         if ($response->failed()) {
             logger()->error('FastAPI Five Question error', ['body' => $response->body()]);

--- a/app/Http/Controllers/Proofreader/ProofreaderController.php
+++ b/app/Http/Controllers/Proofreader/ProofreaderController.php
@@ -12,7 +12,7 @@ class ProofreaderController extends Controller
     public function fetchUserSession()
     {
         $userId = Auth::id();
-        $response = Http::get("http://127.0.0.1:5001/sessions/$userId");
+        $response = Http::get("http://localhost:8006/sessions/$userId");
         return response()->json($response->json());
         // return view('Text Proofreader.proofreader');
     }
@@ -37,7 +37,7 @@ class ProofreaderController extends Controller
 
         $response = Http::timeout(0)
             ->asMultipart()
-            ->post('http://127.0.0.1:5001/proofread', $multipartData);
+            ->post('http://localhost:8006/proofread', $multipartData);
         
         if ($response->failed()) {
             logger()->error('FastAPI Proofreader error', ['body' => $response->body()]);

--- a/app/Http/Controllers/RealWorld/RealWorldController.php
+++ b/app/Http/Controllers/RealWorld/RealWorldController.php
@@ -11,7 +11,7 @@ class RealWorldController extends Controller
     public function fetchUserSession()
     {
         $yserId = Auth::id();
-        $response = Http::get("http://192.168.50.40:8007/sessions/$yserId");
+        $response = Http::get("http://localhost:8007/sessions/$yserId");
         return response()->json($response->json());
         // return view('Real World Connections.realworld');
     }
@@ -36,7 +36,7 @@ class RealWorldController extends Controller
 
     $response = Http::timeout(0)
         ->asMultipart()
-        ->post('http://192.168.50.40:8007/real_world', $multipartData); // Adjusted URL to match your FastAPI endpoint
+        ->post('http://localhost:8007/real_world', $multipartData); // Adjusted URL to match your FastAPI endpoint
 
     if ($response->failed()) {
         logger()->error('FastAPI Real World error', ['body' => $response->body()]);

--- a/app/Http/Controllers/StudyHabits/StudyHabitsController.php
+++ b/app/Http/Controllers/StudyHabits/StudyHabitsController.php
@@ -12,7 +12,7 @@ class StudyHabitsController extends Controller
    public function fetchUserSession()
     {
         $userId = Auth::id();
-        $response = Http::get("http://127.0.1:5001/sessions/$userId");
+        $response = Http::get("http://localhost:8004/sessions/$userId");
         return response()->json($response->json());
         // return view('Text Proofreader.proofreader');
     }
@@ -35,7 +35,7 @@ class StudyHabitsController extends Controller
         ];
         $response = Http::timeout(0)
             ->asMultipart()
-            ->post('http://127.0.1:5001/study_habits', $multipartData); // Adjusted URL to match your FastAPI endpoint
+            ->post('http://localhost:8004/study_habits', $multipartData); // Adjusted URL to match your FastAPI endpoint
         
         if ($response->failed()) {
             logger()->error('FastAPI Study Habits error', ['body' => $response->body()]);

--- a/python/Proofreader/proofreader.py
+++ b/python/Proofreader/proofreader.py
@@ -68,7 +68,7 @@ Changes made:
 
 """
 
-model = OllamaLLM(model="gemma3:latest")
+model = OllamaLLM(model="gemma3:1b")  # Adjust model as needed
 proofreader_prompt = ChatPromptTemplate.from_template(prompt_template)
 
 

--- a/python/five_questions/five_question_agent.py
+++ b/python/five_questions/five_question_agent.py
@@ -17,7 +17,7 @@ from python.chat_router_final import chat_router
 
 
 
-app = FastAPI(debug=True)
+app = FastAPI()
 app.include_router(chat_router)
 
 app.add_middleware(


### PR DESCRIPTION
## Summary by Sourcery

Standardize microservice endpoint URLs across controllers, align Uvicorn command reference, update LLM model version, and disable debug mode in FastAPI apps

Enhancements:
- Use localhost with specific ports for FiveQuestions, Proofreader, RealWorld, and StudyHabits API calls in controllers
- Correct the file_and_app_instance reference for the five_question agent in the Uvicorn console command
- Update the Proofreader service to use the gemma3:1b OllamaLLM model
- Remove debug mode from the five_question FastAPI app instantiation